### PR TITLE
Disable forgery protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  skip_forgery_protection
   before_action :configure_devise, if: :devise_controller?
 
   def not_found


### PR DESCRIPTION
This PR disables rails forgery protection in order to simplify load testing.