### PR TITLE
Initialize games on first load

### DIFF
--- a/config/initializers/games.rb
+++ b/config/initializers/games.rb
@@ -1,0 +1,8 @@
+Rails.configuration.after_initialize do
+  if !Rails.env.test? && Game.count.zero?
+    Game.create!(name: 'League of Legends')
+    Game.create!(name: 'Overwatch')
+    Game.create!(name: 'Minecraft')
+    Game.create!(name: 'Splatoon 2')
+  end
+end


### PR DESCRIPTION
This PR adds a set of initial games if there are none currently in the database.