### PR TITLE
Add login backdoor for load testing

### DIFF
--- a/app/controllers/load_test_controller.rb
+++ b/app/controllers/load_test_controller.rb
@@ -1,0 +1,7 @@
+class LoadTestController < ApplicationController
+  def sign_in_as_new_user
+    new_user = SecureRandom.alphanumeric(10)
+    sign_in(:user, User.create(username: new_user, email: "#{new_user}@example.com", password: new_user))
+    redirect_to root_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,8 @@ Rails.application.routes.draw do
   resources :profiles, path: '/profile', param: :username do
     resources :comments, only: %i[create]
   end
+  namespace :load_test do
+    get 'sign_in_as_new_user'
+  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/load_test_controller_test.rb
+++ b/test/controllers/load_test_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class LoadTestControllerTest < ActionDispatch::IntegrationTest
+  test "sign_in_as_new_user creates new users" do
+    assert_difference 'User.count' do
+      get load_test_sign_in_as_new_user_path
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an endpoint for directly creating new users. This can be used in tsung as follows:
```xml
<request>
  <http method="GET" url="/load_test/sign_in_as_new_user"></http>
</request>
```